### PR TITLE
Fix error invalid data

### DIFF
--- a/src/encryption/aes_gcm_siv.rs
+++ b/src/encryption/aes_gcm_siv.rs
@@ -94,6 +94,10 @@ impl Encryption for AesGcmSivEncryption {
     /// let encrypted_data = enc.decrypt_vec(test_data);
     /// ```
     fn decrypt(&self, bytes: &[u8]) -> String {
+        if bytes.get(12).is_none() {
+            return String::from("")
+        }
+
         let (nonce_bytes, cipher_bytes) = bytes.split_at(12);
         let nonce = GenericArray::from_slice(nonce_bytes);
         let decrypt_vec = self.cipher.decrypt(nonce, cipher_bytes).unwrap();


### PR DESCRIPTION
Found an issue where if a credit card was not found in the database, the decryption segment would panic.  This PR safely checks for enough data to continue or returns default.